### PR TITLE
Superclass and insecure HTTP

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,5 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:usesCleartextTraffic="true"/>
 </manifest>

--- a/lib/authenticationBloc/authentication_bloc.dart
+++ b/lib/authenticationBloc/authentication_bloc.dart
@@ -11,7 +11,8 @@ class AuthenticationBloc
   final UserRepo userRepo;
   final FtcRepository ftcRepository;
   AuthenticationBloc({@required this.userRepo, this.ftcRepository})
-      : assert(userRepo != null);
+      : assert(userRepo != null),
+        super(null);
 
   @override
   AuthenticationState get initialState => AuthenticationUninitialized();

--- a/lib/blocs/adminBloc/admin_bloc.dart
+++ b/lib/blocs/adminBloc/admin_bloc.dart
@@ -7,7 +7,9 @@ import './bloc.dart';
 
 class AdminBloc extends Bloc<AdminEvent, AdminState> {
   final FtcRepository ftcRepository;
-  AdminBloc({@required this.ftcRepository}) : assert(ftcRepository != null);
+  AdminBloc({@required this.ftcRepository})
+      : assert(ftcRepository != null),
+        super(null);
 
   @override
   AdminState get initialState => InitialAdminState();

--- a/lib/blocs/eventsBloc/events_bloc.dart
+++ b/lib/blocs/eventsBloc/events_bloc.dart
@@ -7,7 +7,9 @@ import './bloc.dart';
 
 class EventsBloc extends Bloc<EventsEvent, EventsState> {
   final FtcRepository ftcRepository;
-  EventsBloc({@required this.ftcRepository}) : assert(ftcRepository != null);
+  EventsBloc({@required this.ftcRepository})
+      : assert(ftcRepository != null),
+        super(null);
 
   @override
   EventsState get initialState => InitialEventsState();

--- a/lib/blocs/homeBloc/home_bloc.dart
+++ b/lib/blocs/homeBloc/home_bloc.dart
@@ -8,7 +8,9 @@ import './bloc.dart';
 class HomeBloc extends Bloc<HomeEvent, HomeState> {
   final FtcRepository ftcRepository;
   RouteArgument homePageInfo;
-  HomeBloc({@required this.ftcRepository}) : assert(ftcRepository != null);
+  HomeBloc({@required this.ftcRepository})
+      : assert(ftcRepository != null),
+        super(null);
 
   @override
   HomeState get initialState => InitialHomeState();
@@ -24,7 +26,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     if (event is RefreshHome) {
       yield* _mapGetHomePage();
     }
-
   }
 
   Stream<HomeState> _mapGetHomePage() async* {

--- a/lib/blocs/imageApprovalBloc/image_approval_bloc.dart
+++ b/lib/blocs/imageApprovalBloc/image_approval_bloc.dart
@@ -8,7 +8,8 @@ import './bloc.dart';
 class ImageApprovalBloc extends Bloc<ImageApprovalEvent, ImageApprovalState> {
   final FtcRepository ftcRepository;
   ImageApprovalBloc({@required this.ftcRepository})
-      : assert(ftcRepository != null);
+      : assert(ftcRepository != null),
+        super(null);
   @override
   ImageApprovalState get initialState => InitialImageApprovalState();
 

--- a/lib/blocs/loginBloc/login_bloc.dart
+++ b/lib/blocs/loginBloc/login_bloc.dart
@@ -13,7 +13,8 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     @required this.userRepository,
     @required this.authenticationBloc,
   })  : assert(userRepository != null),
-        assert(authenticationBloc != null);
+        assert(authenticationBloc != null),
+        super(null);
 
   LoginState get initialState => LoginInitial();
 

--- a/lib/blocs/memberBloc/member_bloc.dart
+++ b/lib/blocs/memberBloc/member_bloc.dart
@@ -8,7 +8,9 @@ import './bloc.dart';
 
 class MemberBloc extends Bloc<MemberEvent, MemberState> {
   final FtcRepository ftcRepository;
-  MemberBloc({@required this.ftcRepository}) : assert(ftcRepository != null);
+  MemberBloc({@required this.ftcRepository})
+      : assert(ftcRepository != null),
+        super(null);
   @override
   MemberState get initialState => InitialMemberState();
 

--- a/lib/blocs/memberEventsBloc/member_events_bloc.dart
+++ b/lib/blocs/memberEventsBloc/member_events_bloc.dart
@@ -9,7 +9,8 @@ import './bloc.dart';
 class MemberEventsBloc extends Bloc<MemberEventsEvent, MemberEventsState> {
   final FtcRepository ftcRepository;
   MemberEventsBloc({@required this.ftcRepository})
-      : assert(ftcRepository != null);
+      : assert(ftcRepository != null),
+        super(null);
   @override
   MemberEventsState get initialState => InitialMemberEventsState();
 

--- a/lib/blocs/memberJobsBloc/member_jobs_bloc.dart
+++ b/lib/blocs/memberJobsBloc/member_jobs_bloc.dart
@@ -9,7 +9,8 @@ import './bloc.dart';
 class MemberJobsBloc extends Bloc<MemberJobsEvent, MemberJobsState> {
   final FtcRepository ftcRepository;
   MemberJobsBloc({@required this.ftcRepository})
-      : assert(ftcRepository != null);
+      : assert(ftcRepository != null),
+        super(null);
   @override
   MemberJobsState get initialState => InitialMemberJobsState();
 

--- a/lib/blocs/memberTasksBloc/member_tasks_bloc.dart
+++ b/lib/blocs/memberTasksBloc/member_tasks_bloc.dart
@@ -8,7 +8,8 @@ import './bloc.dart';
 class MemberTasksBloc extends Bloc<MemberTasksEvent, MemberTasksState> {
   final FtcRepository ftcRepository;
   MemberTasksBloc({@required this.ftcRepository})
-      : assert(ftcRepository != null);
+      : assert(ftcRepository != null),
+        super(null);
   @override
   MemberTasksState get initialState => InitialMemberTasksState();
 

--- a/lib/blocs/notificationBloc/notification_bloc.dart
+++ b/lib/blocs/notificationBloc/notification_bloc.dart
@@ -7,7 +7,8 @@ import './bloc.dart';
 class NotificationBloc extends Bloc<NotificationEvent, NotificationState> {
   final FtcRepository ftcRepository;
   NotificationBloc({@required this.ftcRepository})
-      : assert(ftcRepository != null);
+      : assert(ftcRepository != null),
+        super(null);
   @override
   NotificationState get initialState => InitialNotificationState();
 

--- a/lib/blocs/pointsBloc/points_bloc.dart
+++ b/lib/blocs/pointsBloc/points_bloc.dart
@@ -7,7 +7,9 @@ import './bloc.dart';
 
 class PointsBloc extends Bloc<PointsEvent, PointsState> {
   final FtcRepository ftcRepository;
-  PointsBloc({@required this.ftcRepository}) : assert(ftcRepository != null);
+  PointsBloc({@required this.ftcRepository})
+      : assert(ftcRepository != null),
+        super(null);
 
   @override
   PointsState get initialState => InitialPointsState();


### PR DESCRIPTION
This branch fixes an issues with some of the bloc files not including "super(null);", which doesn't allow the app to build.
- Fixed using vscode quick fix, but [here's a source to a similar fix.](https://stackoverflow.com/questions/64954284/the-superclass-blocxxx-xxx-doesnt-have-a-zero-argument-constructor-in-dart)

This branch also implements the usesCleartextTraffic="true" snippet fix in AndroidManifest.xml for the insecure HTTP error when trying to sign in. This only affects the debug version of the app and is not to be included in a release version.
- [Source to fix.](https://flutter.dev/docs/release/breaking-changes/network-policy-ios-android#allowing-cleartext-connection-for-debug-builds)
