### PR TITLE
Correct image_crop in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you notice a bug, have a new feature to suggest, or just want to discuss some
 * [flutter_speed_dial](https://pub.dev/packages/flutter_speed_dial)
 * [google_maps_flutter](https://pub.dev/packages/google_maps_flutter)
 * [google_maps_place_picker](https://pub.dev/packages/google_maps_place_picker)
-* [image_croppe](https://pub.dev/packages/image_croppe)
+* [image_crop](https://pub.dev/packages/image_crop)
 * [image_picker](https://pub.dev/packages/image_picker)
 * [json_annotation](https://pub.dev/packages/json_annotation)
 * [meta](https://pub.dev/packages/meta)


### PR DESCRIPTION
### This branch includes:
- A correction to **image_crop** under **Packages being used in project**, corrects name and link.